### PR TITLE
Automatic encode and split of message

### DIFF
--- a/JamaaTech.SMPP.Net.Lib/DataCoding.cs
+++ b/JamaaTech.SMPP.Net.Lib/DataCoding.cs
@@ -15,8 +15,6 @@
  ************************************************************************/
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using JamaaTech.Smpp.Net.Lib.Protocol;
 
 namespace JamaaTech.Smpp.Net.Lib

--- a/JamaaTech.SMPP.Net.Lib/SmppClientSession.cs
+++ b/JamaaTech.SMPP.Net.Lib/SmppClientSession.cs
@@ -159,7 +159,10 @@ namespace JamaaTech.Smpp.Net.Lib
             SendPduBase(pdu);
             if (pdu.HasResponse) 
             {
-                try { return vRespHandler.WaitResponse(pdu, timeout); }
+                try
+                {
+                    return vRespHandler.WaitResponse(pdu, timeout);
+                }
                 catch (SmppResponseTimedOutException)
                 {
                     if (vTraceSwitch.TraceWarning)
@@ -172,10 +175,20 @@ namespace JamaaTech.Smpp.Net.Lib
 
         private void SendPduBase(PDU pdu)
         {
-            if (pdu == null) { throw new ArgumentNullException("pdu"); }
+            if (pdu == null)
+            {
+                throw new ArgumentNullException("pdu");
+            }
+
             if (!(CheckState(pdu) && (pdu.AllowedSource & SmppEntityType.ESME) == SmppEntityType.ESME))
-            { throw new SmppException(SmppErrorCode.ESME_RINVBNDSTS, "Incorrect bind status for given command"); }
-            try { vTrans.Send(pdu); }
+            {
+                throw new SmppException(SmppErrorCode.ESME_RINVBNDSTS, "Incorrect bind status for given command");
+            }
+
+            try
+            {
+                vTrans.Send(pdu);
+            }
             catch (Exception ex)
             {
                 if (vTraceSwitch.TraceInfo)

--- a/JamaaTech.SMPP.Net.Lib/SmppException.cs
+++ b/JamaaTech.SMPP.Net.Lib/SmppException.cs
@@ -51,5 +51,10 @@ namespace JamaaTech.Smpp.Net.Lib
             throw smppEx;
         }
         #endregion
+
+        public override string ToString()
+        {
+            return string.Format("{0}: {1}{2}{3}", ErrorCode, Message, Environment.NewLine, base.ToString());
+        }
     }
 }

--- a/JamaaTech.SMPP.Net.Lib/Util/SMPPEncodingUtil.cs
+++ b/JamaaTech.SMPP.Net.Lib/Util/SMPPEncodingUtil.cs
@@ -15,15 +15,12 @@
  ************************************************************************/
 
 using System;
-using System.Collections.Generic;
 using System.Text;
-using JamaaTech.Smpp.Net.Lib;
 
 namespace JamaaTech.Smpp.Net.Lib.Util
 {
     public static class SMPPEncodingUtil
     {
-        #region Methods
         public static byte[] GetBytesFromInt(uint value)
         {
             byte[] result = new byte[4];
@@ -75,19 +72,27 @@ namespace JamaaTech.Smpp.Net.Lib.Util
 
         public static byte[] GetBytesFromCString(string cStr, DataCoding dataCoding)
         {
-            if (cStr == null) { throw new ArgumentNullException("cStr"); }
-            if (cStr.Length == 0) { return new byte[] { 0x00 }; }
+            if (cStr == null)
+            {
+                throw new ArgumentNullException("cStr");
+            }
+
+            if (cStr.Length == 0)
+            {
+                return new byte[] { 0x00 };
+            }
+
             byte[] bytes = null;
             switch (dataCoding)
             {
                 case DataCoding.ASCII:
-                    bytes = System.Text.Encoding.ASCII.GetBytes(cStr);
+                    bytes = Encoding.ASCII.GetBytes(cStr);
                     break;
                 case DataCoding.Latin1:
                     bytes = Latin1Encoding.GetBytes(cStr);
                     break;
                 case DataCoding.UCS2:
-                    bytes = System.Text.Encoding.Unicode.GetBytes(cStr);
+                    bytes = Encoding.BigEndianUnicode.GetBytes(cStr);
                     break;
                 case DataCoding.SMSCDefault:
                     bytes = SMSCDefaultEncoding.GetBytes(cStr);
@@ -95,6 +100,7 @@ namespace JamaaTech.Smpp.Net.Lib.Util
                 default:
                     throw new SmppException(SmppErrorCode.ESME_RUNKNOWNERR, "Unsupported encoding");
             }
+
             ByteBuffer buffer = new ByteBuffer(bytes, bytes.Length + 1);
             buffer.Append(new byte[] { 0x00 }); //Append a null charactor a the end
             return buffer.ToBytes();
@@ -107,15 +113,32 @@ namespace JamaaTech.Smpp.Net.Lib.Util
 
         public static string GetCStringFromBytes(byte[] data, DataCoding dataCoding)
         {
-            if (data == null) { throw new ArgumentNullException("data"); }
-            if (data.Length < 1) { throw new ArgumentException("Array cannot be empty","data"); }
-            if (data[data.Length - 1] != 0x00) { throw new ArgumentException("CString must be terminated with a null charactor","data"); }
-            if (data.Length == 1) { return ""; } //The string is empty if it contains a single null charactor
+            if (data == null)
+            {
+                throw new ArgumentNullException("data");
+            }
+
+            if (data.Length < 1)
+            {
+                throw new ArgumentException("Array cannot be empty","data");
+            }
+
+            if (data[data.Length - 1] != 0x00)
+            {
+                throw new ArgumentException("CString must be terminated with a null charactor","data");
+            }
+
+            //The string is empty if it contains a single null charactor
+            if (data.Length == 1)
+            {
+                return "";
+            }
+            
             string result = null;
             switch (dataCoding)
             {
                 case DataCoding.ASCII:
-                    result = System.Text.Encoding.ASCII.GetString(data);
+                    result = Encoding.ASCII.GetString(data);
                     break;
                 case DataCoding.Latin1:
                     result = Latin1Encoding.GetString(data);
@@ -124,12 +147,14 @@ namespace JamaaTech.Smpp.Net.Lib.Util
                     result = SMSCDefaultEncoding.GetString(data);
                     break;
                 case DataCoding.UCS2:
-                    result = System.Text.Encoding.Unicode.GetString(data);
+                    result = Encoding.BigEndianUnicode.GetString(data);
                     break;
                 default:
                     throw new SmppException(SmppErrorCode.ESME_RUNKNOWNERR, "Unsupported encoding");
             }
-            return result.Replace("\x00","");//Replace the terminating null charactor
+
+            //Replace the terminating null charactor
+            return result.Replace("\x00","");
         }
 
         public static byte[] GetBytesFromString(string cStr)
@@ -137,7 +162,7 @@ namespace JamaaTech.Smpp.Net.Lib.Util
             return GetBytesFromCString(cStr, DataCoding.ASCII);
         }
 
-        public static byte[] GetBytesFromString(string cStr,DataCoding dataCoding)
+        public static byte[] GetBytesFromString(string cStr, DataCoding dataCoding)
         {
             if (cStr == null) { throw new ArgumentNullException("cStr"); }
             if (cStr.Length == 0) { return new byte[] { 0x00 }; }
@@ -145,13 +170,13 @@ namespace JamaaTech.Smpp.Net.Lib.Util
             switch (dataCoding)
             {
                 case DataCoding.ASCII:
-                    bytes = System.Text.Encoding.ASCII.GetBytes(cStr);
+                    bytes = Encoding.ASCII.GetBytes(cStr);
                     break;
                 case DataCoding.Latin1:
                     bytes = Latin1Encoding.GetBytes(cStr);
                     break;
                 case DataCoding.UCS2:
-                    bytes = System.Text.Encoding.Unicode.GetBytes(cStr);
+                    bytes = Encoding.BigEndianUnicode.GetBytes(cStr);
                     break;
                 case DataCoding.SMSCDefault:
                     bytes = SMSCDefaultEncoding.GetBytes(cStr);
@@ -169,12 +194,16 @@ namespace JamaaTech.Smpp.Net.Lib.Util
 
         public static string GetStringFromBytes(byte[] data, DataCoding dataCoding)
         {
-            if (data == null) { throw new ArgumentNullException("data"); }
+            if (data == null)
+            {
+                throw new ArgumentNullException("data");
+            }
+
             string result = null;
             switch (dataCoding)
             {
                 case DataCoding.ASCII:
-                    result = System.Text.Encoding.ASCII.GetString(data);
+                    result = Encoding.ASCII.GetString(data);
                     break;
                 case DataCoding.Latin1:
                     result = Latin1Encoding.GetString(data);
@@ -183,17 +212,16 @@ namespace JamaaTech.Smpp.Net.Lib.Util
                     result = SMSCDefaultEncoding.GetString(data);
                     break;
                 case DataCoding.UCS2:
-                    result = System.Text.Encoding.Unicode.GetString(data);
+                    result = Encoding.BigEndianUnicode.GetString(data);
                     break;
                 default:
                     throw new SmppException(SmppErrorCode.ESME_RUNKNOWNERR, "Unsupported encoding");
             }
+
             //Since a CString may contain a null terminating charactor
             //Replace all occurences of null charactors
             return result.Replace("\u0000","");
 
         }
-        
-        #endregion
     }
 }

--- a/JamaaTech.Smpp.Net.Client/IShortMessage.cs
+++ b/JamaaTech.Smpp.Net.Client/IShortMessage.cs
@@ -1,0 +1,36 @@
+﻿
+namespace JamaaTech.Smpp.Net.Client
+{
+    interface IShortMessage
+    {
+        /// <summary>
+        /// Gets the <see cref="IShortMessage"/> source address
+        /// </summary>
+        string SourceAddress { get; }
+
+        /// <summary>
+        /// Gets the <see cref="IShortMessage"/> destination address
+        /// </summary>
+        string DestinationAddress { get; }
+
+        /// <summary>
+        /// Tells if a delivery notification is required
+        /// </summary>
+        bool RegisterDeliveryNotification { get; }
+
+        /// <summary>
+        /// Gets the index of this message segment in a group of contatenated message segements
+        /// </summary>
+        int SegmentID { get; }
+
+        /// <summary>
+        /// Gets the message count
+        /// </summary>
+        int MessageCount { get; }
+
+        /// <summary>
+        /// Gets the message
+        /// </summary>
+        string Text { get; }
+    }
+}

--- a/JamaaTech.Smpp.Net.Client/ISmppClient.cs
+++ b/JamaaTech.Smpp.Net.Client/ISmppClient.cs
@@ -1,0 +1,137 @@
+﻿using System;
+
+namespace JamaaTech.Smpp.Net.Client
+{
+    public interface ISmppClient : IDisposable
+    {
+        /// <summary>
+        /// Occurs when a message is received
+        /// </summary>
+        event EventHandler<MessageEventArgs> MessageReceived;
+
+        /// <summary>
+        /// Occurs when a message delivery notification is received
+        /// </summary>
+        event EventHandler<MessageEventArgs> MessageDelivered;
+
+        /// <summary>
+        /// Occurs when connection state changes
+        /// </summary>
+        event EventHandler<ConnectionStateChangedEventArgs> ConnectionStateChanged;
+
+        /// <summary>
+        /// Occurs when a message is successfully sent
+        /// </summary>
+        event EventHandler<MessageEventArgs> MessageSent;
+
+        /// <summary>
+        /// Occurs when <see cref="ISmppClient"/> is started or shut down
+        /// </summary>
+        event EventHandler<StateChangedEventArgs> StateChanged;
+
+        /// <summary>
+        /// Gets or sets a value indicating the time in miliseconds to wait before attemping to reconnect after a connection is lost
+        /// </summary>
+        int AutoReconnectDelay { get; set; }
+
+        /// <summary>
+        /// Indicates the current state of <see cref="ISmppClient"/>
+        /// </summary>
+        SmppConnectionState ConnectionState { get; }
+
+        /// <summary>
+        /// Gets or sets a value that indicates the time in miliseconds in which Enquire Link PDUs are periodically sent
+        /// </summary>
+        int KeepAliveInterval { get; set; }
+
+        /// <summary>
+        /// Gets an instance of <see cref="SmppConnectionProperties"/> that represents connection properties for this <see cref="ISmppClient"/>
+        /// </summary>
+        SmppConnectionProperties ConnectionProperties { get; }
+
+        /// <summary>
+        /// Gets or sets a value that speficies the amount of time after which a synchronous <see cref="ISmppClient.SendMessage"/> call will timeout
+        /// </summary>
+        int ConnectionTimeout { get; set; }
+
+        /// <summary>
+        /// Gets a <see cref="System.Boolean"/> value indicating if an instance of <see cref="ISmppClient"/> is started
+        /// </summary>
+        bool Started { get; }
+
+        /// <summary>
+        /// Immediately attempts to reestablish a lost connection without waiting for <see cref="ISmppClient"/> to automatically reconnect
+        /// </summary>
+        void Connect();
+
+        /// <summary>
+        /// Immediately attempts to reestablish a lost connection without waiting for <see cref="ISmppClient"/> to automatically reconnect
+        /// </summary>
+        /// <param name="timeout">A time in miliseconds after which a connection operation times out</param>
+        void Connect(int timeout);
+
+        /// <summary>
+        /// Disconnects <see cref="ISmppClient"/> from the remote SMPP server 
+        /// </summary>
+        void Disconnect();
+
+        /// <summary>
+        /// Starts <see cref="ISmppClient"/> and immediately connects to a remote SMPP server
+        /// </summary>
+        void Start();
+
+        /// <summary>
+        /// Starts <see cref="ISmppClient"/> and waits for a specified amount of time before establishing connection
+        /// </summary>
+        /// <param name="connectDelay">A value in miliseconds to wait before establishing connection</param>
+        void Start(int delay);
+
+        /// <summary>
+        /// Stop <see cref="ISmppClient"/>
+        /// </summary>
+        void Stop();
+
+        /// <summary>
+        /// Restarts <see cref="ISmppClient"/>
+        /// </summary>
+        void Restart();
+
+        /// <summary>
+        /// Sends message to a remote SMMP server
+        /// </summary>
+        /// <param name="message">A message to send</param>
+        /// <param name="timeOut">A value in miliseconds after which the send operation times out</param>
+        void SendMessage(TextMessage message, int timeOut);
+
+        /// <summary>
+        /// Sends message to a remote SMPP server
+        /// </summary>
+        /// <param name="message">A message to send</param>
+        void SendMessage(TextMessage message);
+
+        /// <summary>
+        /// Sends message asynchronously to a remote SMPP server
+        /// </summary>
+        /// <param name="message">A message to send</param>
+        /// <param name="timeout">A value in miliseconds after which the send operation times out</param>
+        /// <param name="callback">An <see cref="AsyncCallback"/> delegate</param>
+        /// <param name="state">An object that contains state information for this request</param>
+        /// <returns>An <see cref="IAsyncResult"/> that references the asynchronous send message operation</returns>
+        IAsyncResult BeginSendMessage(TextMessage message, int timeout, AsyncCallback callback, object state);
+
+        /// <summary>
+        /// Sends message asynchronously to a remote SMPP server
+        /// </summary>
+        /// <param name="message">A message to send</param>
+        /// <param name="callback">An <see cref="AsyncCallback"/> delegate</param>
+        /// <param name="state">An object that contains state information for this request</param>
+        /// <returns>An <see cref="IAsyncResult"/> that references the asynchronous send message operation</returns>
+        IAsyncResult BeginSendMessage(TextMessage message, AsyncCallback callback, object state);
+
+        /// <summary>
+        /// Ends a pending asynchronous send message operation
+        /// </summary>
+        /// <param name="result">An <see cref="IAsyncResult"/> that stores state information for this asynchronous operation</param>
+        void EndSendMessage(IAsyncResult result);
+    }
+}

--- a/JamaaTech.Smpp.Net.Client/MessageFactory.cs
+++ b/JamaaTech.Smpp.Net.Client/MessageFactory.cs
@@ -24,27 +24,25 @@ namespace JamaaTech.Smpp.Net.Client
     /// </summary>
     public static class MessageFactory
     {
-        #region Methods
         /// <summary>
-        /// Creates a <see cref="TextMessage"/> from a received <see cref="SingleDestinationPDU"/>
+        /// Creates a <see cref="RecievedShortMessage"/> from a received <see cref="SingleDestinationPDU"/>
         /// </summary>
-        /// <param name="pdu">The PDU from which a <see cref="TextMessage"/> is constructed</param>
-        /// <returns>A <see cref="TextMessage"/> represening a text message extracted from the received PDU</returns>
-        public static TextMessage CreateMessage(SingleDestinationPDU pdu)
+        /// <param name="pdu">The PDU from which a <see cref="RecievedShortMessage"/> is constructed</param>
+        /// <returns>A <see cref="RecievedShortMessage"/> represening a text message extracted from the received PDU</returns>
+        public static RecievedShortMessage CreateMessage(SingleDestinationPDU pdu)
         {
             //This version supports only text messages
             Udh udh = null;
-            string message = null;
+            string message = string.Empty;
             pdu.GetMessageText(out message, out udh);
-            TextMessage sms = null;
             //Check if the udh field is present
-            if (udh != null) { sms = new TextMessage(udh.SegmentID, udh.MessageCount, udh.MessageSequence); }
-            else { sms = new TextMessage(); }
-            sms.Text = message == null ? "" : message;
-            sms.SourceAddress = pdu.SourceAddress.Address;
-            sms.DestinationAddress = pdu.DestinationAddress.Address;
-            return sms;
+            //if (udh != null) { sms = new TextMessage(udh.SegmentID, udh.MessageCount, udh.MessageSequence); }
+            if (udh != null)
+            {
+                return new RecievedShortMessage(udh.SegmentID, udh.MessageCount, udh.MessageSequence, pdu.SourceAddress.Address, pdu.DestinationAddress.Address, message, pdu.RegisteredDelivery == RegisteredDelivery.DeliveryReceipt);
+            }
+
+            return new RecievedShortMessage(pdu.SourceAddress.Address, pdu.DestinationAddress.Address, message, pdu.RegisteredDelivery == RegisteredDelivery.DeliveryReceipt);
         }
-        #endregion
     }
 }

--- a/JamaaTech.Smpp.Net.Client/RecievedShortMessage.cs
+++ b/JamaaTech.Smpp.Net.Client/RecievedShortMessage.cs
@@ -1,0 +1,19 @@
+﻿
+namespace JamaaTech.Smpp.Net.Client
+{
+    public class RecievedShortMessage : ShortMessage
+    {
+        internal RecievedShortMessage(string sourceAddress, string destinatinAddress, string text, bool deliveryNotification = false)
+            : base(sourceAddress, destinatinAddress, text, deliveryNotification)
+        {
+        }
+
+        public int Sequence { get; private set; }
+
+        internal RecievedShortMessage(int segmentId, int maxCount, int sequence, string sourceAddress, string destinatinAddress, string text, bool deliveryNotification = false)
+            : base(segmentId, maxCount, sourceAddress, destinatinAddress, text, deliveryNotification)
+        {
+            Sequence = sequence;
+        }
+    }
+}

--- a/JamaaTech.Smpp.Net.Client/SendMessageCallBack.cs
+++ b/JamaaTech.Smpp.Net.Client/SendMessageCallBack.cs
@@ -22,5 +22,5 @@ namespace JamaaTech.Smpp.Net.Client
     /// </summary>
     /// <param name="message">A message to send</param>
     /// <param name="timeout">A value indicating the time in miliseconds after which the send operation times out</param>
-    internal delegate void SendMessageCallBack(ShortMessage message,int timeout);
+    internal delegate void SendMessageCallBack(TextMessage message,int timeout);
 }

--- a/JamaaTech.Smpp.Net.Client/ShortMessage.cs
+++ b/JamaaTech.Smpp.Net.Client/ShortMessage.cs
@@ -14,105 +14,38 @@
  *
  ************************************************************************/
 
-using System;
-using System.Text;
-using System.Collections.Generic;
-using JamaaTech.Smpp.Net.Lib.Protocol;
-using JamaaTech.Smpp.Net.Lib;
-
 namespace JamaaTech.Smpp.Net.Client
 {
     /// <summary>
     /// Defines a base class for diffent types of messages that can be used with <see cref="SmppClient"/>
     /// </summary>
-    public abstract class ShortMessage
+    public class ShortMessage : IShortMessage
     {
-        #region Variables
-        protected string vSourceAddress;
-        protected string vDestinatinoAddress;
-        protected int vMessageCount;
-        protected int vSegmentID;
-        protected int vSequenceNumber;
-        protected bool vRegisterDeliveryNotification;
-        #endregion
-
-        #region Constructors
-        public ShortMessage()
+        public ShortMessage(string sourceAddress, string destinatinAddress, string text, bool deliveryNotification = false)
         {
-            vSourceAddress = "";
-            vDestinatinoAddress = "";
-            vSegmentID = -1;
+            SourceAddress = sourceAddress;
+            DestinationAddress = destinatinAddress;
+            Text = text;
+            RegisterDeliveryNotification = deliveryNotification;
         }
 
-        public ShortMessage(int segmentId, int messageCount, int sequenceNumber)
-            : base()
+        public ShortMessage(int segmentId, int messageCount, string sourceAddress, string destinatinAddress, string text, bool deliveryNotification = false)
+            : this(sourceAddress, destinatinAddress, text, deliveryNotification)
         {
-            vSegmentID = segmentId;
-            vMessageCount = messageCount;
-            vSequenceNumber = sequenceNumber;
+            SegmentID = segmentId;
+            MessageCount = messageCount;
         }
-        #endregion
+        
+        public string SourceAddress { get; protected set; }
 
-        #region Properties
-        /// <summary>
-        /// Gets or sets a <see cref="ShortMessage"/> source address
-        /// </summary>
-        public string SourceAddress
-        {
-            get { return vSourceAddress; }
-            set { vSourceAddress = value; }
-        }
+        public string DestinationAddress { get; protected set; }
 
-        /// <summary>
-        /// Gets or sets a <see cref="ShortMessage"/> destination address
-        /// </summary>
-        public string DestinationAddress
-        {
-            get { return vDestinatinoAddress; }
-            set { vDestinatinoAddress = value; }
-        }
+        public int SegmentID { get; protected set; }
 
-        /// <summary>
-        /// Gets the index of this message segment in a group of contatenated message segements
-        /// </summary>
-        public int SegmentID
-        {
-            get { return vSegmentID; }
-        }
+        public int MessageCount { get; protected set; }
 
-        /// <summary>
-        /// Gets the sequence number for a group of concatenated message segments
-        /// </summary>
-        public int SequenceNumber
-        {
-            get { return vSequenceNumber; }
-        }
+        public string Text { get; protected set; }
 
-        /// <summary>
-        /// Gets a value indicating the total number of message segments in a concatenated message
-        /// </summary>
-        public int MessageCount
-        {
-            get { return vMessageCount; }
-        }
-
-        /// <summary>
-        /// Gets or sets a <see cref="System.Boolean"/> value that indicates if a delivery notification should be sent for <see cref="ShortMessage"/>
-        /// </summary>
-        public bool RegisterDeliveryNotification
-        {
-            get { return vRegisterDeliveryNotification; }
-            set { vRegisterDeliveryNotification = value; }
-        }
-        #endregion
-
-        #region Methods
-        internal IEnumerable<SendSmPDU> GetMessagePDUs(DataCoding defaultEncoding)
-        {
-            return GetPDUs(defaultEncoding);
-        }
-
-        protected abstract IEnumerable<SendSmPDU> GetPDUs(DataCoding defaultEncoding);
-        #endregion
+        public bool RegisterDeliveryNotification { get; protected set; }
     }
 }

--- a/JamaaTech.Smpp.Net.Client/Smpp.Net.Client.csproj
+++ b/JamaaTech.Smpp.Net.Client/Smpp.Net.Client.csproj
@@ -43,9 +43,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConnectionStateChangedEventArgs.cs" />
+    <Compile Include="IShortMessage.cs" />
+    <Compile Include="ISmppClient.cs" />
     <Compile Include="MessageEventArgs.cs" />
     <Compile Include="MessageFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RecievedShortMessage.cs" />
     <Compile Include="SendMessageCallBack.cs" />
     <Compile Include="ShortMessage.cs" />
     <Compile Include="SmppClient.cs" />

--- a/JamaaTech.Smpp.Net.Client/SmppConnectionProperties.cs
+++ b/JamaaTech.Smpp.Net.Client/SmppConnectionProperties.cs
@@ -15,8 +15,6 @@
  ************************************************************************/
 
 using System;
-using System.Text;
-using System.Collections.Generic;
 using JamaaTech.Smpp.Net.Lib;
 
 namespace JamaaTech.Smpp.Net.Client


### PR DESCRIPTION
SmppClient now distinguishes between messages that are being sent and received and abstracted the logic for splitting messages.

You still have to concatenate messages received into one big message, but you will receive the segmentId, sequence number and count so it shouldn't be a problem.
Still only has encoding for: ASCII, Latin1, USC2.
